### PR TITLE
add CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,4 @@
+# This file is described here:  https://help.github.com/en/articles/about-code-owners
+
+# Global Owners: These are brigadecore org maintainers + maintainers of this repo
+* @brigadecore/maintainers @brigadecore/community-maintainers


### PR DESCRIPTION
This PR adds the absent CODEOWNERS file.

Note that it is slightly different than the CODEOWNERS file in sibling repos.

Something I want to try here is having this code owned not only by the org maintainers, but also by a separate team of repo-specific maintainers.

Our governance docs do, after all, make a distinction between repo maintainers and org maintainers, but we have not enforced that distinction until now.

The practical reason for doing this is that it paves the way for @karenhchu  to be made a maintainer of _this_ repo, but not the whole org.

If this works out well, we should consider adding a new team per repo, but I am not going to rush ahead and do that until this model proves itself out. This is a test case.

