### PR TITLE
add public org maintainers list

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,24 @@
+# Brigade Maintainers
+
+Maintainer permissions within GitHub are governed by membership in the
+__@brigadecore/maintainers__ team, but because the membership of this team is
+not publicly visible, this document serves as the public record of individuals
+with authority and accountability for _all_ repositories within the
+__@brigadecore__ GitHub org.
+
+Individual repositories within the __@brigadecore__ GitHub org may have
+_additional_ maintainers, and in such cases, will have their own
+`MAINTAINERS.md` linking back to here and listing those additional individuals. 
+
+## brigadecore Org Maintainers
+
+* [Matt Butcher](https://github.com/technosophos)
+* [Vaughn Dice](https://github.com/vdice)
+* [Radu Matei](https://github.com/radu-matei)
+* [Kent Rancourt](https://github.com/krancour)
+
+## brigadecore Org Maintainers Emeritus
+
+* [Yusuke Kuoka](https://github.com/mumoshu)
+* [Luke Patrick](https://github.com/lukepatrick)
+* [Adam Reese](https://github.com/adamreese)


### PR DESCRIPTION
The `CODEOWNERS` file in each repo points to ownership by the @brigadecore/maintainers team (and sometimes additional teams with a narrower scope of authority/accountability), but the membership of these teams is _not_ publicly visible, making it a dead end.

This PR adds a _public_ record of who our org-wide maintainers are.

Follow up PRs to applicable repos with add similar documents for repos that have additional maintainers beyond this core group.