### PR TITLE
update codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
 # This file is described here:  https://help.github.com/en/articles/about-code-owners
 
 # Global Owners: These are brigadecore org maintainers + maintainers of this repo
-* @brigadecore/maintainers @brigadecore/community-maintainers
+* @brigadecore/maintainers @karenhchu @flynnduism


### PR DESCRIPTION
There are, as of recently, a few private repositories in the @brigadecore org. In order to limit access to those repositories to core maintainers only, no one else should be in the @brigadecore org. As a result, I've turned non-core maintainers who maintain individual repositories into outside collaborators. This means they cannot be members of teams under @brigadecore... so this PR updates `CODEOWNERS` to explicitly name individual non-core maintainers for this repository instead of naming a now-empty team.